### PR TITLE
Fix entity relationship mismatch between Player and SaveGame

### DIFF
--- a/apps/server/src/entities/player.entity.ts
+++ b/apps/server/src/entities/player.entity.ts
@@ -2,8 +2,7 @@ import {
   Entity,
   PrimaryKey,
   Property,
-  Collection,
-  OneToMany,
+  OneToOne,
   Unique,
 } from '@mikro-orm/core';
 import { v4 } from 'uuid';
@@ -18,8 +17,8 @@ export class Player {
   @Unique()
   name!: string;
 
-  @OneToMany(() => SaveGame, (save) => save.player)
-  saves = new Collection<SaveGame>(this);
+  @OneToOne(() => SaveGame, (save) => save.player)
+  save?: SaveGame;
 
   @Property({ onCreate: () => new Date() })
   createdAt: Date = new Date();


### PR DESCRIPTION
## Summary

- Fix MikroORM metadata error caused by incompatible relationship types
- Change `Player.saves` (OneToMany/Collection) to `Player.save` (OneToOne) to match `SaveGame.player`'s OneToOne relationship

## Context

Commit 2d4feb6 ("allow only one save per user") changed `SaveGame.player` to `@OneToOne` but didn't update the inverse side in `Player`, causing the deployment to fail with:

```
MetadataError: Player.saves is of type 1:m which is incompatible with its owning side SaveGame.player of type 1:1
```

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (231 tests)
- [ ] Deploy and verify server starts without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)