### PR TITLE
Fix save command failure (Issue #7)

### DIFF
--- a/apps/server/src/database/database.module.ts
+++ b/apps/server/src/database/database.module.ts
@@ -48,7 +48,15 @@ export class DatabaseModule implements OnModuleInit {
   async onModuleInit() {
     const generator = this.orm.getSchemaGenerator();
     // Use safe mode to only create missing tables, never drop/alter existing ones
-    await generator.updateSchema({ safe: true, dropTables: false });
-    this.logger.log('Database schema updated');
+    try {
+      await generator.updateSchema({ safe: true, dropTables: false });
+      this.logger.log('Database schema updated');
+    } catch (error) {
+      this.logger.error(
+        'Schema update failed',
+        error instanceof Error ? error.stack : error,
+      );
+      this.logger.warn('Database may need manual migration. See README.');
+    }
   }
 }

--- a/apps/server/src/entities/player.entity.ts
+++ b/apps/server/src/entities/player.entity.ts
@@ -17,7 +17,7 @@ export class Player {
   @Unique()
   name!: string;
 
-  @OneToOne(() => SaveGame, (save) => save.player)
+  @OneToOne(() => SaveGame, { mappedBy: 'player' })
   save?: SaveGame;
 
   @Property({ onCreate: () => new Date() })

--- a/apps/server/src/entities/save-game.entity.ts
+++ b/apps/server/src/entities/save-game.entity.ts
@@ -12,7 +12,7 @@ export class SaveGame {
   @PrimaryKey()
   id: string = v4();
 
-  @OneToOne(() => Player, { unique: true })
+  @OneToOne(() => Player, { owner: true })
   player!: Player;
 
   @Property({ type: 'json' })

--- a/apps/server/src/save/save.service.ts
+++ b/apps/server/src/save/save.service.ts
@@ -37,7 +37,10 @@ export class SaveService {
       this.logger.log(`Game saved for ${playerName}`);
       return true;
     } catch (error) {
-      this.logger.error(`Failed to save game: ${error}`);
+      this.logger.error(
+        'Failed to save game',
+        error instanceof Error ? error.stack : error,
+      );
       return false;
     }
   }
@@ -53,7 +56,10 @@ export class SaveService {
 
       return save.gameData;
     } catch (error) {
-      this.logger.error(`Failed to load game: ${error}`);
+      this.logger.error(
+        'Failed to load game',
+        error instanceof Error ? error.stack : error,
+      );
       return null;
     }
   }


### PR DESCRIPTION
## Summary

- Fix MikroORM OneToOne relationship misconfiguration between Player and SaveGame entities
- Configure Player as inverse side (`mappedBy`) and SaveGame as owning side (`owner: true`)
- Improve error logging in SaveService to include stack traces for easier debugging
- Add error handling around schema updates in DatabaseModule to prevent crashes

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (231 tests)
- [x] Test save command locally with database connected
- [x] Verify SaveGame records are created in database
- [x] Test load command retrieves saved game

## Notes

Before deploying to production, run this SQL to remove duplicate saves from previous schema:
```sql
DELETE FROM save_game
WHERE id NOT IN (
  SELECT DISTINCT ON (player_id) id
  FROM save_game
  ORDER BY player_id, updated_at DESC
);
```

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)